### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ master] 
 
+permissions:
+  contents: read
+
 jobs:
   test-and-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sharp231/my-todo/security/code-scanning/1](https://github.com/sharp231/my-todo/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read-only operations, we will set `contents: read` as the minimal required permission. This ensures that the workflow has the least privilege necessary to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
