### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sharp231/my-todo/security/code-scanning/3](https://github.com/sharp231/my-todo/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the actions performed in the workflow (e.g., checking out code, installing dependencies, building, and testing), the workflow likely only requires read access to the repository contents. Therefore, we will add `permissions: contents: read` at the root level of the workflow file to apply this restriction to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
